### PR TITLE
Remove Dependency on Variable Abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ Indeed, the panel structure is what makes `esplot` a convenient command for rese
 to avoid having to reshape or otherwise prepare the data. This is particularly helpful when individuals
 can have multiple events or if there are multiple *types* of events that the researcher would like to compare.
 
-I am working on adding support to more general settings. **In particular, I am looking
-to add support for settings in which the researcher has already defined a `event time` variable.**
-This would allow `esplot` to be used in a repeated cross-section or other non-panel settings.
-
-Interested users should flag this as an issue, otherwise adding this functionality will remain a medium to long-term goal.
+I am working on adding support to more general settings. **I am currently adding support for settings in which the researcher has already defined a `event time` variable.**
+This would allow `esplot` to be used in a repeated cross-section or other non-panel settings. 
 
 ### For users of older versions of Stata
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,7 @@ This would allow `esplot` to be used in a repeated cross-section or other non-pa
 
 #### Known Bugs
 
-The error code `variable b_0 not found` is thrown when [variable abbreviation is disabled](https://github.com/dballaelliott/esplot/issues/6). 
-
-This is now properly labeled a bug, since this violates coding best practices; I am implementing a hotfix before the v1.0 update. 
+The error code `variable b_0 not found` is thrown when [variable abbreviation is disabled]. **The bug is fixed as of `esplot` 0.8.5 (Feb 1/2021).**
 
 ### For users of older versions of Stata
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ can have multiple events or if there are multiple *types* of events that the res
 I am working on adding support to more general settings. **I am currently adding support for settings in which the researcher has already defined a `event time` variable.**
 This would allow `esplot` to be used in a repeated cross-section or other non-panel settings. 
 
+#### Known Bugs
+
+The error code `variable b_0 not found` is thrown when [variable abbreviation is disabled](https://github.com/dballaelliott/esplot/issues/6). 
+
+This is now properly labeled a bug, since this violates coding best practices; I am implementing a hotfix before the v1.0 update. 
+
 ### For users of older versions of Stata
 
 Currently, this project nominally supports Stata versions as early as 11.

--- a/esplot.ado
+++ b/esplot.ado
@@ -1,7 +1,6 @@
-/*! version 0-alpha-6  3nov2020 Dylan Balla-Elliott, dballaelliott@gmail.com */
+/*! version 0.8.5  1feb2021 Dylan Balla-Elliott, dballaelliott@gmail.com */
 
 program define esplot, eclass sortpreserve
-
 
 version 11
 
@@ -29,36 +28,6 @@ syntax varlist(max=1) [if] [in] [fweight pweight aweight/], ///
 # delimit cr
 
 set more off
-/* V1.0 options
-[SYMmetric /// 
-	graph_both ///
-	triple_dif ///
-	NO_reg ///
-	event_type(string) ///
- 	absorb(varlist fv ts) ///
-	CONTROLs(varlist fv ts) ///
-	cluster(varlist) ///
- 	Quarters(integer 10) ///
-	p_length(integer 3) ///
-	yrange(numlist) ///
-	tag(string) ///
-	label_size(string) ///
-	ylab_fmt(string) ///
- 	t_col(string) ///
-	c_col(string) ///
-	filetype(string) ///
-	event_suffix(string) ///
-	nodd ///
-	one_line ///
- 	NODROP ///
-	mgr_time ///
-	graph_all ///
-	force ///
-	animate ///
-	///
-	horserace ///
- */
-/* TODO: Think about how to remove window, and by */
 
 if "$esplot_nolog" == "" global esplot_nolog 1
 if $esplot_nolog == 1 global esplot_quietly "quietly :"
@@ -478,14 +447,14 @@ foreach x of local by_groups{
 	
 	/* todo: let people pass whatever they want to ci and est opts, including suboptions */
 	if "`est_plot'" == "line"{
-		local b_to_plot `"line b_`x' x, lcolor("`color_id'")"'
+		local b_to_plot `"line b_`x'1 x, lcolor("`color_id'")"'
 	}
 	else if "`est_plot'" == "scatter" | "`est_plot'" == "" {
-		local b_to_plot `"scatter b_`x' x, mcolor("`color_id'")"'
+		local b_to_plot `"scatter b_`x'1 x, mcolor("`color_id'")"'
 	}
 	else {
 		di as error "Unsupported plot type for estimates: `est_plot'. Using default"
-		local b_to_plot `"scatter b_`x' x, mcolor("`color_id'")"'
+		local b_to_plot `"scatter b_`x'1 x, mcolor("`color_id'")"'
 	}
 
 

--- a/esplot.pkg
+++ b/esplot.pkg
@@ -1,8 +1,8 @@
-v 0-alpha-6.0
+v 0.8.5
 
 d esplot: event study plots
 d Dylan Balla-Elliott, Harvard Business School
-d Distribution-Date: 3nov 2020
+d Distribution-Date: 1feb 2021
 
 f esplot.ado
 f esplot.sthlp

--- a/example/make_examples.do
+++ b/example/make_examples.do
@@ -1,7 +1,8 @@
 discard 
 /* do ../esplot.ado */
 
-adopath ++ ".."
+adopath ++ "../"
+
 net install allston, from("https://raw.githubusercontent.com/dballaelliott/allston/master/")
 
 set scheme aurora

--- a/stata.toc
+++ b/stata.toc
@@ -1,4 +1,4 @@
-v 0-alpha-5.0
+v 0.8.5
 
 d binscatter module to generate binned scatterplots
 d Dylan Balla-Elliott, Harvard Business School


### PR DESCRIPTION
Fixes #6 

After disabling variable abbreviation via `set varabbrev off` the patched version of `esplot` successfully executes the test procedure and builds the files in `make_examples.do` 

